### PR TITLE
Remove safe mode from main feature list

### DIFF
--- a/manual/en/toc/features.inc
+++ b/manual/en/toc/features.inc
@@ -42,20 +42,15 @@ $TOC = array (
   ),
   8 =>
   array (
-    0 => 'features.safe-mode.php',
-    1 => 'Safe Mode',
-  ),
-  9 =>
-  array (
     0 => 'features.commandline.php',
     1 => 'Command line usage',
   ),
-  10 =>
+  9 =>
   array (
     0 => 'features.gc.php',
     1 => 'Garbage Collection',
   ),
-  11 =>
+  10 =>
   array (
     0 => 'features.dtrace.php',
     1 => 'DTrace Dynamic Tracing',


### PR DESCRIPTION
Safe mode has been deprecated for a long time. There's no reason it should still be in the list of main features